### PR TITLE
feat: support jujutsu repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: taiki-e/install-action@v2
         with:
-          tool: jj-cli@0.45.0
+          tool: jj-cli@0.44.0
       - run: npm ci
       - run: npm run typecheck
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,14 @@ jobs:
         with:
           node-version: 22.19.0
           cache: npm
+      - name: Install Jujutsu
+        if: runner.os == 'Linux'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: jj-cli@0.45.0
       - run: npm ci
       - run: npm run typecheck
       - run: npm test
+        env:
+          PI_WORKSPACE_HISTORY_REQUIRE_JUJUTSU: ${{ runner.os == 'Linux' && '1' || '0' }}
       - run: git diff --check

--- a/.pi/extensions/workspace-history.ts
+++ b/.pi/extensions/workspace-history.ts
@@ -25,7 +25,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 
 const SNAPSHOT_TYPE = "workspace-history.snapshot";
-const SNAPSHOT_RETENTION_REF_PREFIX = "refs/workspace-history/snapshots";
+const SNAPSHOT_RETENTION_REF_PREFIX = "refs/wh/s";
 const ACTIVE_SESSION_LEASE_FILE = "active-session.json";
 
 const DEFAULT_MAX_SESSIONS_PER_WORKSPACE = 3;

--- a/.pi/extensions/workspace-history.ts
+++ b/.pi/extensions/workspace-history.ts
@@ -40,6 +40,7 @@ const RESTORE_FILE_LOCK_RETRY_DELAYS_MS = [100, 250, 500] as const;
 const WORKSPACE_HISTORY_LOG_ENV = "PI_WORKSPACE_HISTORY_LOG";
 const PROJECT_MARKER_FILES = [
   ".git",
+  ".jj",
   "package.json",
   "pnpm-workspace.yaml",
   "pyproject.toml",
@@ -237,6 +238,7 @@ interface SessionLease {
 
 const DEFAULT_EXCLUDES = [
   ".git",
+  ".jj",
   ".pi/workspace-history",
   "node_modules",
   "dist",
@@ -402,6 +404,20 @@ async function hasProjectMarker(cwd: string): Promise<boolean> {
   }
 }
 
+async function isInsideJujutsuMetadata(cwd: string): Promise<boolean> {
+  let current = await realpath(cwd).catch(() => path.resolve(cwd));
+  for (;;) {
+    if (normalizePathForComparison(path.basename(current)) === normalizePathForComparison(".jj")) {
+      return true;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return false;
+    }
+    current = parent;
+  }
+}
+
 function normalizePathForComparison(filePath: string): string {
   const normalized = path.normalize(filePath);
   return process.platform === "win32" ? normalized.toLowerCase() : normalized;
@@ -485,6 +501,8 @@ async function evaluateWorkspaceHistoryAvailability(ctx: ExtensionContext, state
     };
   } else if (settings.enabled === false) {
     availability = { enabled: false, reason: "disabled by configuration" };
+  } else if (await isInsideJujutsuMetadata(ctx.cwd)) {
+    availability = { enabled: false, reason: "current directory is inside Jujutsu metadata" };
   } else if (settings.enabled === true) {
     availability = { enabled: true };
   } else {

--- a/README.md
+++ b/README.md
@@ -106,19 +106,24 @@ This plugin is built around the following concrete requirements:
 
 The plugin stores snapshots in an internal shadow git repository instead of relying on the user's project `.git` history.
 
+The same file-history workflow works in Git repositories, Jujutsu repositories, and colocated Git/Jujutsu repositories. Repository metadata (`.git/` and `.jj/`) is never snapshotted or restored. Consequently, workspace undo restores file contents but does not rewind Git commits, branches, or the index, nor Jujutsu commits, bookmarks, or operations. After an undo, `git status` or `jj status` may show the restored files as working-copy changes; use the VCS's own recovery commands when repository history must also change.
+
+The extension still requires the Git executable for its private shadow repository, including when the workspace itself uses only Jujutsu.
+
 A single undo unit lasts from the original prompt until Pi reports that the agent is settled. Intermediate tool rounds receive their own tree anchors, but queued input never replaces the operation's original prompt or `before` snapshot. One `/undo` therefore removes the complete result of a multi-round operation, and `/redo` restores it as a unit.
 
 For conversation-only navigation without a branch summary, the plugin first resolves any pending recovery from an earlier interrupted restore. If files changed after that interrupted restore, those later edits are kept automatically. The plugin then snapshots the current files before moving the conversation and uses the snapshot as the seed of the continued history branch. Once the conversation continues, its normal visible message nodes restore that kept workspace state through `/tree`. Cancelling the choice leaves both conversation and workspace unchanged. In non-interactive modes, navigation keeps the previous combined conversation-and-workspace behavior.
 
 Default snapshot scope:
 
-- Git tracked files
-- Untracked files that are not ignored
+- Files already managed by the internal shadow repository
+- New files that are not ignored
 - Paths matched by the workspace `.gitignore` are filtered out even if they were previously snapshotted
 
 Default exclusions:
 
 - `.git/`
+- `.jj/`
 - `.pi/workspace-history/`
 - `node_modules/`
 - `dist/`
@@ -179,11 +184,13 @@ Settings:
   - Allow enabling in the user home directory
   - Default: `false`
 - `workspaceHistory.requireProjectMarker`
-  - Require a project marker such as `.git`, `package.json`, `Cargo.toml`, `go.mod`, or `pyproject.toml` in the current directory or an ancestor
+  - Require a project marker such as `.git`, `.jj`, `package.json`, `Cargo.toml`, `go.mod`, or `pyproject.toml` in the current directory or an ancestor
   - Default: `true`
   - When `false`, automatic mode accepts any directory except a filesystem root or the user home directory (unless `allowHomeDirectory` is also enabled)
-- `workspaceHistory.maxScanFiles` / `workspaceHistory.maxScanDirs` / `workspaceHistory.maxScanMs`
-  - Safety budget for workspace scanning
+- `workspaceHistory.maxScanFiles`
+- `workspaceHistory.maxScanDirs`
+- `workspaceHistory.maxScanMs`
+  - Safety limits for restore-time workspace scans
 - `workspaceHistory.gitTimeoutMs`
   - Timeout for internal git operations
 
@@ -237,6 +244,7 @@ npm run typecheck
 
 ## Recent Changes
 
+- Git, Jujutsu, and colocated repositories share the same file-history workflow while their VCS metadata remains untouched
 - Complete multi-round agent operations now form one undo/redo unit
 - Hard exclusions remain unmanaged even when `.gitignore` contains negation rules
 - Project markers are detected in ancestor directories for Git, Rust, Go, Python, and other declared project types

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -106,19 +106,24 @@
 
 插件内部使用独立的 shadow git 来保存快照，而不是依赖用户项目本身的 `.git` 历史。
 
+同一套文件历史流程可用于 Git 仓库、Jujutsu 仓库以及 Git/Jujutsu colocated 仓库。仓库元数据（`.git/` 和 `.jj/`）不会进入快照，也不会被恢复。因此，工作区撤销只恢复文件内容，不会回退 Git 的 commit、branch 或 index，也不会回退 Jujutsu 的 commit、bookmark 或 operation。撤销后，`git status` 或 `jj status` 可能会把恢复的文件显示为工作区修改；如需回退仓库历史，请使用对应 VCS 自身的恢复命令。
+
+即使工作区只使用 Jujutsu，扩展仍需要 Git 可执行文件来维护私有 shadow 仓库。
+
 一个撤销单元从原始 prompt 开始，直到 Pi 报告 Agent 已 settled 为止。中间工具轮次各自拥有 `/tree` 锚点，但排队输入不会替换该操作最初的 prompt 或 `before` 快照。因此，一次 `/undo` 会完整撤销多轮工具调用的全部结果，`/redo` 也会把它作为整体恢复。
 
 只回退对话且不生成分支摘要时，插件会先处理此前中断恢复留下的待恢复工作；如果中断恢复后文件又被修改，这些后续修改会自动保留。随后插件快照当前文件，并将其作为后续历史分支的起点。继续对话后，分支中正常可见的消息节点即可通过 `/tree` 恢复这份保留的工作区状态。取消选择时，对话和工作区都不改变；非交互模式继续沿用原来的“对话和工作区一起恢复”行为。
 
 默认快照范围：
 
-- Git tracked 文件
-- 未被 ignore 的 untracked 文件
+- 已由内部 shadow 仓库纳管的文件
+- 未被 ignore 的新文件
 - 命中工作区 `.gitignore` 的路径会被过滤掉，即使它们此前已经进入过快照范围
 
 默认排除：
 
 - `.git/`
+- `.jj/`
 - `.pi/workspace-history/`
 - `node_modules/`
 - `dist/`
@@ -179,11 +184,13 @@
   - 是否允许在用户 home 目录启用
   - 默认：`false`
 - `workspaceHistory.requireProjectMarker`
-  - 是否要求当前目录或祖先目录存在 `.git`、`package.json`、`Cargo.toml`、`go.mod`、`pyproject.toml` 等项目标记
+  - 是否要求当前目录或祖先目录存在 `.git`、`.jj`、`package.json`、`Cargo.toml`、`go.mod`、`pyproject.toml` 等项目标记
   - 默认：`true`
   - 设为 `false` 时，自动模式允许文件系统根目录和用户 home 目录以外的任意目录（home 目录仍需同时启用 `allowHomeDirectory`）
-- `workspaceHistory.maxScanFiles` / `workspaceHistory.maxScanDirs` / `workspaceHistory.maxScanMs`
-  - 工作区扫描的安全预算
+- `workspaceHistory.maxScanFiles`
+- `workspaceHistory.maxScanDirs`
+- `workspaceHistory.maxScanMs`
+  - 恢复时扫描工作区的安全限制
 - `workspaceHistory.gitTimeoutMs`
   - 插件内部 git 操作超时时间
 
@@ -237,6 +244,7 @@ npm run typecheck
 
 ## 最近更新
 
+- Git、Jujutsu 和 colocated 仓库共用同一套文件历史流程，同时保持各自的 VCS 元数据不变
 - 完整的多轮 Agent 操作现在作为一个 undo / redo 单元
 - 即使 `.gitignore` 使用反向规则，硬排除路径也不会重新被纳管
 - Git、Rust、Go、Python 等项目标记可从祖先目录识别

--- a/tests/workspace-history.test.ts
+++ b/tests/workspace-history.test.ts
@@ -1,5 +1,4 @@
-import { access, copyFile, mkdtemp, mkdir, readFile, readdir, rm, utimes, writeFile } from "node:fs/promises";
-import { realpathSync } from "node:fs";
+import { access, copyFile, mkdtemp, mkdir, readFile, readdir, realpath, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import assert from "node:assert/strict";
@@ -52,6 +51,8 @@ type TurnSnapshotState = {
   }>;
 };
 
+const workspaceHashByCwd = new Map<string, string>();
+
 const execFileAsync = promisify(execFile);
 
 async function hasJujutsu(): Promise<boolean> {
@@ -81,6 +82,11 @@ async function getJujutsuOperationId(cwd: string): Promise<string> {
 const ASYNC_ASSERTION_TIMEOUT_MS = 15_000;
 
 async function createContextForWorkspace(rootDir: string, cwd: string, withProjectMarker = true): Promise<TestContext> {
+  const resolvedCwd = await realpath(cwd).catch(() => path.resolve(cwd));
+  workspaceHashByCwd.set(
+    path.normalize(cwd),
+    createHash("sha256").update(path.normalize(resolvedCwd)).digest("hex").slice(0, 24),
+  );
   const settingsManager = SettingsManager.inMemory({
     compaction: { enabled: false },
     retry: { enabled: false, maxRetries: 0 },
@@ -171,6 +177,7 @@ async function writeWorkspaceHistorySettings(
 }
 
 async function disposeContext(ctx: TestContext): Promise<void> {
+  workspaceHashByCwd.delete(path.normalize(ctx.cwd));
   await rm(ctx.rootDir, {
     recursive: true,
     force: true,
@@ -477,13 +484,9 @@ async function holdWindowsFileWithoutDeleteSharing(
 }
 
 function getWorkspaceHash(cwd: string): string {
-  let resolvedCwd: string;
-  try {
-    resolvedCwd = realpathSync(cwd);
-  } catch {
-    resolvedCwd = path.resolve(cwd);
-  }
-  return createHash("sha256").update(path.normalize(resolvedCwd)).digest("hex").slice(0, 24);
+  const workspaceHash = workspaceHashByCwd.get(path.normalize(cwd));
+  assert.ok(workspaceHash, `workspace hash was not registered for ${cwd}`);
+  return workspaceHash;
 }
 
 function getSessionHistoryDir(session: Awaited<ReturnType<typeof createSession>>, cwd: string): string {

--- a/tests/workspace-history.test.ts
+++ b/tests/workspace-history.test.ts
@@ -2952,7 +2952,7 @@ async function testFailedShadowRepoRebuildDoesNotLeaveCanonicalRepo(): Promise<v
 
       await assert.rejects(
         session2.prompt("create after rebuild retry"),
-        /Unable to rebuild shadow repository[\s\S]*(?:tree|object)/i,
+        /Unable to rebuild shadow repository[\s\S]*(?:tree|object|does not appear to be a git repository)/i,
         "a corrupt reusable source should surface the Git rebuild failure",
       );
       assert.equal(await pathExists(session2GitDir), false, "failed rebuild should not leave a repo at the canonical path");

--- a/tests/workspace-history.test.ts
+++ b/tests/workspace-history.test.ts
@@ -52,6 +52,7 @@ type TurnSnapshotState = {
 };
 
 const workspaceHashByCwd = new Map<string, string>();
+const SNAPSHOT_RETENTION_REF_PREFIX = "refs/wh/s";
 
 const execFileAsync = promisify(execFile);
 
@@ -1932,10 +1933,13 @@ async function testNewSessionReusesWorkspaceShadowRepo(): Promise<void> {
     const session1GitDir = getShadowGitDir(session1, ctx1.cwd);
     const retainedSessionRefs = await execFileAsync(
       "git",
-      ["--git-dir", session1GitDir, "for-each-ref", "--format=%(refname)", "refs/workspace-history"],
+      ["--git-dir", session1GitDir, "for-each-ref", "--format=%(refname)", SNAPSHOT_RETENTION_REF_PREFIX],
       { cwd: ctx1.cwd },
     );
-    assert.match(retainedSessionRefs.stdout, /refs\/workspace-history\/snapshots\//, "session repo should retain snapshot refs");
+    assert.ok(
+      retainedSessionRefs.stdout.includes(`${SNAPSHOT_RETENTION_REF_PREFIX}/`),
+      "session repo should retain snapshot refs",
+    );
     session1.dispose();
 
     const ctx2 = await createContextForWorkspace(ctx1.rootDir, ctx1.cwd);
@@ -1959,12 +1963,12 @@ async function testNewSessionReusesWorkspaceShadowRepo(): Promise<void> {
 
     const secondSessionSnapshots = (await readTurnSnapshots(session2, ctx2.cwd)).turns;
     const expectedRetentionRefs = new Set(secondSessionSnapshots.flatMap((turn) => [
-      `refs/workspace-history/snapshots/${turn.beforeCommit}`,
-      `refs/workspace-history/snapshots/${turn.afterCommit}`,
+      `${SNAPSHOT_RETENTION_REF_PREFIX}/${turn.beforeCommit}`,
+      `${SNAPSHOT_RETENTION_REF_PREFIX}/${turn.afterCommit}`,
     ]));
     const inheritedRetentionRefs = await execFileAsync(
       "git",
-      ["--git-dir", gitDir, "for-each-ref", "--format=%(refname)", "refs/workspace-history"],
+      ["--git-dir", gitDir, "for-each-ref", "--format=%(refname)", SNAPSHOT_RETENTION_REF_PREFIX],
       { cwd: ctx1.cwd },
     );
     assert.deepEqual(
@@ -3555,7 +3559,7 @@ async function testBranchSnapshotsSurviveGitPrune(): Promise<void> {
 
     await execFileAsync(
       "git",
-      ["--git-dir", gitDir, "update-ref", "-d", `refs/workspace-history/snapshots/${cCommit}`],
+      ["--git-dir", gitDir, "update-ref", "-d", `${SNAPSHOT_RETENTION_REF_PREFIX}/${cCommit}`],
       { cwd: ctx.cwd },
     );
     await pruneUnreachableGitObjects(gitDir, ctx.cwd);
@@ -3593,7 +3597,7 @@ async function testMissingPreviousSnapshotFallsBackToFreshBefore(): Promise<void
     await execFileAsync("git", ["--git-dir", gitDir, "update-ref", headRef, first.beforeCommit], { cwd: ctx.cwd });
     await execFileAsync(
       "git",
-      ["--git-dir", gitDir, "update-ref", "-d", `refs/workspace-history/snapshots/${first.afterCommit}`],
+      ["--git-dir", gitDir, "update-ref", "-d", `${SNAPSHOT_RETENTION_REF_PREFIX}/${first.afterCommit}`],
       { cwd: ctx.cwd },
     );
     await pruneUnreachableGitObjects(gitDir, ctx.cwd);
@@ -3632,7 +3636,7 @@ async function testSessionStartRebuildsSnapshotRetentionRefs(): Promise<void> {
 
     const refs = await execFileAsync(
       "git",
-      ["--git-dir", gitDir, "for-each-ref", "--format=%(refname)", "refs/workspace-history"],
+      ["--git-dir", gitDir, "for-each-ref", "--format=%(refname)", SNAPSHOT_RETENTION_REF_PREFIX],
       { cwd: ctx1.cwd },
     );
     for (const ref of refs.stdout.split(/\r?\n/).filter((value) => value.length > 0)) {
@@ -3644,7 +3648,7 @@ async function testSessionStartRebuildsSnapshotRetentionRefs(): Promise<void> {
     await waitFor(async () => {
       const rebuiltRefs = await execFileAsync(
         "git",
-        ["--git-dir", gitDir, "for-each-ref", "--format=%(refname)", "refs/workspace-history"],
+        ["--git-dir", gitDir, "for-each-ref", "--format=%(refname)", SNAPSHOT_RETENTION_REF_PREFIX],
         { cwd: ctx1.cwd },
       );
       return rebuiltRefs.stdout.includes(turn.beforeCommit) && rebuiltRefs.stdout.includes(turn.afterCommit);

--- a/tests/workspace-history.test.ts
+++ b/tests/workspace-history.test.ts
@@ -77,7 +77,7 @@ async function getJujutsuOperationId(cwd: string): Promise<string> {
   return stdout.trim();
 }
 
-const ASYNC_ASSERTION_TIMEOUT_MS = process.env.CI ? 30_000 : 15_000;
+const ASYNC_ASSERTION_TIMEOUT_MS = process.env.CI && process.platform === "win32" ? 60_000 : 15_000;
 
 async function createContextForWorkspace(rootDir: string, cwd: string, withProjectMarker = true): Promise<TestContext> {
   const settingsManager = SettingsManager.inMemory({

--- a/tests/workspace-history.test.ts
+++ b/tests/workspace-history.test.ts
@@ -77,7 +77,7 @@ async function getJujutsuOperationId(cwd: string): Promise<string> {
   return stdout.trim();
 }
 
-const ASYNC_ASSERTION_TIMEOUT_MS = 15_000;
+const ASYNC_ASSERTION_TIMEOUT_MS = process.env.CI ? 30_000 : 15_000;
 
 async function createContextForWorkspace(rootDir: string, cwd: string, withProjectMarker = true): Promise<TestContext> {
   const settingsManager = SettingsManager.inMemory({
@@ -170,17 +170,12 @@ async function writeWorkspaceHistorySettings(
 }
 
 async function disposeContext(ctx: TestContext): Promise<void> {
-  for (let attempt = 0; attempt < 5; attempt += 1) {
-    try {
-      await rm(ctx.rootDir, { recursive: true, force: true });
-      return;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EBUSY") {
-        throw error;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 150));
-    }
-  }
+  await rm(ctx.rootDir, {
+    recursive: true,
+    force: true,
+    maxRetries: 10,
+    retryDelay: 100,
+  });
 }
 
 async function createSession(ctx: TestContext, sessionManager: SessionManager = SessionManager.inMemory(ctx.cwd)) {

--- a/tests/workspace-history.test.ts
+++ b/tests/workspace-history.test.ts
@@ -59,6 +59,9 @@ async function hasJujutsu(): Promise<boolean> {
     return true;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      if (process.env.PI_WORKSPACE_HISTORY_REQUIRE_JUJUTSU === "1") {
+        throw new Error("Jujutsu is required for this test run, but jj was not found on PATH");
+      }
       return false;
     }
     throw error;

--- a/tests/workspace-history.test.ts
+++ b/tests/workspace-history.test.ts
@@ -1939,12 +1939,25 @@ async function testNewSessionReusesWorkspaceShadowRepo(): Promise<void> {
     await waitFor(async () => await pathExists(path.join(gitDir, "objects")), "second session shadow git repo should exist", 10000);
     const head = await readFile(path.join(gitDir, "HEAD"), "utf8");
     assert.match(head, /refs\/heads|[0-9a-f]{40}/, "second session should have a cloned shadow repo with HEAD");
+    ctx2.provider.setResponses([fauxAssistantMessage("verified reusable shadow state")]);
+    await session2.prompt("verify reusable shadow state");
+    await waitFor(async () => await countSnapshots(session2, ctx2.cwd, "after") >= 1, "second session snapshot was not created");
+
+    const secondSessionSnapshots = (await readTurnSnapshots(session2, ctx2.cwd)).turns;
+    const expectedRetentionRefs = new Set(secondSessionSnapshots.flatMap((turn) => [
+      `refs/workspace-history/snapshots/${turn.beforeCommit}`,
+      `refs/workspace-history/snapshots/${turn.afterCommit}`,
+    ]));
     const inheritedRetentionRefs = await execFileAsync(
       "git",
       ["--git-dir", gitDir, "for-each-ref", "--format=%(refname)", "refs/workspace-history"],
       { cwd: ctx1.cwd },
     );
-    assert.equal(inheritedRetentionRefs.stdout.trim(), "", "new sessions should not inherit another session's retention refs");
+    assert.deepEqual(
+      new Set(inheritedRetentionRefs.stdout.trim().split(/\r?\n/).filter(Boolean)),
+      expectedRetentionRefs,
+      "new sessions should retain only commits referenced by their own history",
+    );
 
     session2.dispose();
     ctx2.provider.unregister();

--- a/tests/workspace-history.test.ts
+++ b/tests/workspace-history.test.ts
@@ -1,4 +1,5 @@
 import { access, copyFile, mkdtemp, mkdir, readFile, readdir, rm, utimes, writeFile } from "node:fs/promises";
+import { realpathSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import assert from "node:assert/strict";
@@ -77,7 +78,7 @@ async function getJujutsuOperationId(cwd: string): Promise<string> {
   return stdout.trim();
 }
 
-const ASYNC_ASSERTION_TIMEOUT_MS = process.env.CI && process.platform === "win32" ? 60_000 : 15_000;
+const ASYNC_ASSERTION_TIMEOUT_MS = 15_000;
 
 async function createContextForWorkspace(rootDir: string, cwd: string, withProjectMarker = true): Promise<TestContext> {
   const settingsManager = SettingsManager.inMemory({
@@ -475,8 +476,18 @@ async function holdWindowsFileWithoutDeleteSharing(
   };
 }
 
+function getWorkspaceHash(cwd: string): string {
+  let resolvedCwd: string;
+  try {
+    resolvedCwd = realpathSync(cwd);
+  } catch {
+    resolvedCwd = path.resolve(cwd);
+  }
+  return createHash("sha256").update(path.normalize(resolvedCwd)).digest("hex").slice(0, 24);
+}
+
 function getSessionHistoryDir(session: Awaited<ReturnType<typeof createSession>>, cwd: string): string {
-  const workspaceHash = createHash("sha256").update(path.normalize(cwd)).digest("hex").slice(0, 24);
+  const workspaceHash = getWorkspaceHash(cwd);
   return path.join(
     getWorkspaceHistoryStateDir(path.dirname(cwd)),
     "workspaces",
@@ -1926,7 +1937,7 @@ async function testNewSessionReusesWorkspaceShadowRepo(): Promise<void> {
 
     const ctx2 = await createContextForWorkspace(ctx1.rootDir, ctx1.cwd);
     const session2 = await createSession(ctx2);
-    const workspaceHash = createHash("sha256").update(path.normalize(ctx1.cwd)).digest("hex").slice(0, 24);
+    const workspaceHash = getWorkspaceHash(ctx1.cwd);
     const gitDir = path.join(
       getWorkspaceHistoryStateDir(ctx1.rootDir),
       "workspaces",
@@ -2121,7 +2132,7 @@ async function testRetentionCleanupHonorsCrossProcessLease(): Promise<void> {
       storageDir: getWorkspaceHistoryStateDir(ctx1.rootDir),
       maxSessionsPerWorkspace: 1,
     });
-    const workspaceHash = createHash("sha256").update(path.normalize(ctx1.cwd)).digest("hex").slice(0, 24);
+    const workspaceHash = getWorkspaceHash(ctx1.cwd);
     const sessionsRoot = path.join(
       getWorkspaceHistoryStateDir(ctx1.rootDir),
       "workspaces",
@@ -2197,7 +2208,7 @@ async function testRetentionCleanupRequiresValidMetadata(): Promise<void> {
       maxWorkspaces: 2,
     });
     const storageDir = getWorkspaceHistoryStateDir(ctx.rootDir);
-    const workspaceHash = createHash("sha256").update(path.normalize(ctx.cwd)).digest("hex").slice(0, 24);
+    const workspaceHash = getWorkspaceHash(ctx.cwd);
     const workspaceRoot = path.join(storageDir, "workspaces", workspaceHash);
     const sessionsRoot = path.join(workspaceRoot, "sessions");
 
@@ -2269,7 +2280,7 @@ async function testRetentionCleanupLogsDeletionFailure(): Promise<void> {
       storageDir: getWorkspaceHistoryStateDir(ctx.rootDir),
       maxSessionsPerWorkspace: 1,
     });
-    const workspaceHash = createHash("sha256").update(path.normalize(ctx.cwd)).digest("hex").slice(0, 24);
+    const workspaceHash = getWorkspaceHash(ctx.cwd);
     const oldSessionRoot = path.join(
       getWorkspaceHistoryStateDir(ctx.rootDir),
       "workspaces",
@@ -2977,7 +2988,7 @@ async function testStaleShadowRepoLockIsRecovered(): Promise<void> {
       fauxAssistantMessage("created lock recovery file"),
     ]);
 
-    const workspaceHash = createHash("sha256").update(path.normalize(ctx.cwd)).digest("hex").slice(0, 24);
+    const workspaceHash = getWorkspaceHash(ctx.cwd);
     const sessionRoot = path.join(
       getWorkspaceHistoryStateDir(ctx.rootDir),
       "workspaces",
@@ -3122,7 +3133,7 @@ async function testRestoreFailureDoesNotDeleteCurrentWorkspace(): Promise<void> 
     await waitFor(async () => await countSnapshots(session, ctx.cwd, "after") >= 1, "safe file after snapshot was not created");
 
     const sessionId = session.sessionManager.getSessionId();
-    const workspaceHash = createHash("sha256").update(ctx.cwd).digest("hex").slice(0, 24);
+    const workspaceHash = getWorkspaceHash(ctx.cwd);
     const workspaceRoot = path.join(getWorkspaceHistoryStateDir(ctx.rootDir), "workspaces", workspaceHash);
     const gitDir = path.join(workspaceRoot, "sessions", sessionId, "repo.git");
     await rm(gitDir, { recursive: true, force: true });
@@ -3559,13 +3570,9 @@ async function testBranchSnapshotsSurviveGitPrune(): Promise<void> {
 }
 
 async function testMissingPreviousSnapshotFallsBackToFreshBefore(): Promise<void> {
-  const previousLogging = process.env.PI_WORKSPACE_HISTORY_LOG;
-  process.env.PI_WORKSPACE_HISTORY_LOG = "1";
-  let ctx: TestContext | undefined;
+  const ctx = await createContext();
   try {
-    ctx = await createContext();
     const session = await createSession(ctx);
-    const notifications = captureNotifications(session);
     ctx.provider.setResponses([
       fauxAssistantMessage([fauxToolCall("write", { path: "missing-snapshot.txt", content: "first\n" })]),
       fauxAssistantMessage("created first state"),
@@ -3573,16 +3580,7 @@ async function testMissingPreviousSnapshotFallsBackToFreshBefore(): Promise<void
     ]);
 
     await session.prompt("create first state");
-    try {
-      await waitFor(async () => await countSnapshots(session, ctx.cwd, "after") === 1, "first snapshot missing");
-    } catch (error) {
-      const logFile = path.join(getWorkspaceHistoryStateDir(ctx.rootDir), "logs", "timemachine.log");
-      const diagnosticLog = await readFile(logFile, "utf8").catch((logError) => `Unable to read ${logFile}: ${String(logError)}`);
-      throw new Error(
-        `First snapshot diagnostic failed. Notifications: ${notifications.join(" | ") || "none"}\n${diagnosticLog}`,
-        { cause: error },
-      );
-    }
+    await waitFor(async () => await countSnapshots(session, ctx.cwd, "after") === 1, "first snapshot missing");
     const first = (await readTurnSnapshots(session, ctx.cwd)).turns[0];
     assert.ok(first, "first turn snapshot should exist");
     assert.notEqual(first.beforeCommit, first.afterCommit, "fixture requires a distinct after commit");
@@ -3607,14 +3605,7 @@ async function testMissingPreviousSnapshotFallsBackToFreshBefore(): Promise<void
     await execFileAsync("git", ["--git-dir", gitDir, "cat-file", "-e", `${recovered.beforeCommit}^{commit}`], { cwd: ctx.cwd });
     session.dispose();
   } finally {
-    if (previousLogging === undefined) {
-      delete process.env.PI_WORKSPACE_HISTORY_LOG;
-    } else {
-      process.env.PI_WORKSPACE_HISTORY_LOG = previousLogging;
-    }
-    if (ctx) {
-      await disposeContext(ctx);
-    }
+    await disposeContext(ctx);
   }
 }
 

--- a/tests/workspace-history.test.ts
+++ b/tests/workspace-history.test.ts
@@ -52,6 +52,28 @@ type TurnSnapshotState = {
 };
 
 const execFileAsync = promisify(execFile);
+
+async function hasJujutsu(): Promise<boolean> {
+  try {
+    await execFileAsync("jj", ["--version"]);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function getJujutsuOperationId(cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync(
+    "jj",
+    ["--ignore-working-copy", "--no-pager", "-R", cwd, "op", "log", "-n", "1", "--no-graph", "-T", "id"],
+    { cwd },
+  );
+  return stdout.trim();
+}
+
 const ASYNC_ASSERTION_TIMEOUT_MS = 15_000;
 
 async function createContextForWorkspace(rootDir: string, cwd: string, withProjectMarker = true): Promise<TestContext> {
@@ -1378,6 +1400,251 @@ async function testNonProjectWorkspaceDisablesExtension(): Promise<void> {
 
     await session.prompt("create activated.txt");
     await waitFor(async () => (await countSnapshots(session, ctx.cwd, "after")) >= 1, "workspace history should re-enable after adding a project marker");
+
+    session.dispose();
+  } finally {
+    await disposeContext(ctx);
+  }
+}
+
+async function testJujutsuOnlyWorkspacePreservesMetadata(): Promise<void> {
+  if (!await hasJujutsu()) {
+    return;
+  }
+
+  const ctx = await createNonProjectContext();
+  try {
+    await execFileAsync("jj", ["--quiet", "git", "init", "--no-colocate", "."], { cwd: ctx.cwd });
+    assert.equal(await pathExists(path.join(ctx.cwd, ".git")), false, "the fixture should be a non-colocated Jujutsu repository");
+    const operationId = await getJujutsuOperationId(ctx.cwd);
+    await writeWorkspaceHistorySettings(ctx, {
+      storageDir: getWorkspaceHistoryStateDir(ctx.rootDir),
+      maxScanFiles: 3,
+    });
+
+    const session = await createSession(ctx);
+    const notifications = captureNotifications(session);
+    const filePath = path.join(ctx.cwd, "managed.txt");
+    ctx.provider.setResponses([
+      fauxAssistantMessage([fauxToolCall("write", { path: "managed.txt", content: "managed\n" })]),
+      fauxAssistantMessage("created managed file"),
+    ]);
+
+    await session.prompt("create managed.txt");
+    await waitFor(async () => await countSnapshots(session, ctx.cwd, "after") >= 1, "Jujutsu workspace snapshot was not created");
+
+    const { stdout: trackedPaths } = await execFileAsync("git", shadowGitArgs(session, ctx.cwd, "ls-files"), { cwd: ctx.cwd });
+    assert.doesNotMatch(trackedPaths, /(^|\n)\.jj\//, "Jujutsu metadata must not enter snapshot history");
+
+    await session.prompt("/undo");
+    await waitForExists(filePath, false, `Jujutsu workspace undo failed: ${notifications.join(" | ")}`);
+    assert.equal(await getJujutsuOperationId(ctx.cwd), operationId, "workspace undo must not change Jujutsu operations");
+
+    await session.prompt("/redo");
+    await waitForText(filePath, "managed\n", "Jujutsu workspace redo should restore managed files");
+    assert.equal(await getJujutsuOperationId(ctx.cwd), operationId, "workspace redo must not change Jujutsu operations");
+
+    const { stdout: jjStatus } = await execFileAsync("jj", ["--no-pager", "status"], { cwd: ctx.cwd });
+    assert.match(jjStatus, /managed\.txt/, "Jujutsu should report the restored file as a working-copy change");
+
+    session.dispose();
+  } finally {
+    await disposeContext(ctx);
+  }
+}
+
+async function testJujutsuMetadataDirectoryDisablesExtension(): Promise<void> {
+  if (!await hasJujutsu()) {
+    return;
+  }
+
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pi-timemachine-test-"));
+  const repositoryDir = path.join(rootDir, "workspace");
+  await mkdir(repositoryDir, { recursive: true });
+  await execFileAsync("jj", ["--quiet", "git", "init", "--no-colocate", "."], { cwd: repositoryDir });
+  const ctx = await createContextForWorkspace(rootDir, path.join(repositoryDir, ".jj", "repo"), false);
+  try {
+    await writeWorkspaceHistorySettings(ctx, {
+      enabled: true,
+      storageDir: getWorkspaceHistoryStateDir(rootDir),
+    });
+    const session = await createSession(ctx);
+    ctx.provider.setResponses([
+      fauxAssistantMessage([fauxToolCall("write", { path: "agent-output.txt", content: "created\n" })]),
+      fauxAssistantMessage("created output"),
+    ]);
+
+    await session.prompt("create agent-output.txt");
+
+    assert.equal(await countSnapshots(session, ctx.cwd), 0, "workspace history must stay disabled inside .jj metadata");
+    assert.equal(await pathExists(getWorkspaceHistoryStateDir(rootDir)), false, "workspace history must not create storage inside .jj metadata");
+    session.dispose();
+  } finally {
+    await disposeContext(ctx);
+  }
+}
+
+async function testGitRepositoryMetadataRemainsUntouched(): Promise<void> {
+  const ctx = await createNonProjectContext();
+  try {
+    await execFileAsync("git", ["init", "-q"], { cwd: ctx.cwd });
+    await execFileAsync("git", ["config", "user.name", "workspace-history-test"], { cwd: ctx.cwd });
+    await execFileAsync("git", ["config", "user.email", "workspace-history-test@local"], { cwd: ctx.cwd });
+    await writeFile(path.join(ctx.cwd, "repository.txt"), "repository state\n", "utf8");
+    await execFileAsync("git", ["add", "repository.txt"], { cwd: ctx.cwd });
+    await execFileAsync("git", ["commit", "-m", "test repository state"], { cwd: ctx.cwd });
+    const userHead = await readText(path.join(ctx.cwd, ".git", "HEAD"));
+    const userIndex = await readFile(path.join(ctx.cwd, ".git", "index"));
+
+    const session = await createSession(ctx);
+    const managedPath = path.join(ctx.cwd, "git-managed.txt");
+    ctx.provider.setResponses([
+      fauxAssistantMessage([fauxToolCall("write", { path: "git-managed.txt", content: "managed\n" })]),
+      fauxAssistantMessage("created Git managed file"),
+    ]);
+
+    await session.prompt("create git-managed.txt");
+    await waitFor(async () => await countSnapshots(session, ctx.cwd, "after") >= 1, "Git workspace snapshot was not created");
+    const { stdout: trackedPaths } = await execFileAsync("git", shadowGitArgs(session, ctx.cwd, "ls-files"), { cwd: ctx.cwd });
+    assert.doesNotMatch(trackedPaths, /(^|\n)\.git\//, "Git metadata must not enter snapshot history");
+
+    await session.prompt("/undo");
+    await waitForExists(managedPath, false, "Git workspace undo should remove the managed file");
+    assert.equal(await readText(path.join(ctx.cwd, ".git", "HEAD")), userHead, "workspace undo must not change Git HEAD");
+    assert.deepEqual(await readFile(path.join(ctx.cwd, ".git", "index")), userIndex, "workspace undo must not change the Git index");
+
+    await session.prompt("/redo");
+    await waitForText(managedPath, "managed\n", "Git workspace redo should restore the managed file");
+    assert.equal(await readText(path.join(ctx.cwd, ".git", "HEAD")), userHead, "workspace redo must not change Git HEAD");
+    assert.deepEqual(await readFile(path.join(ctx.cwd, ".git", "index")), userIndex, "workspace redo must not change the Git index");
+
+    const { stdout: gitStatus } = await execFileAsync("git", ["status", "--short"], { cwd: ctx.cwd });
+    assert.match(gitStatus, /git-managed\.txt/, "Git should report the restored file as a working-tree change");
+
+    session.dispose();
+  } finally {
+    await disposeContext(ctx);
+  }
+}
+
+async function testConcurrentSessionsInJujutsuWorkspace(): Promise<void> {
+  if (!await hasJujutsu()) {
+    return;
+  }
+
+  const ctx1 = await createNonProjectContext();
+  let ctx2: TestContext | undefined;
+  const sessions: Array<Awaited<ReturnType<typeof createSession>>> = [];
+  try {
+    await execFileAsync("jj", ["--quiet", "git", "init", "--no-colocate", "."], { cwd: ctx1.cwd });
+    const operationId = await getJujutsuOperationId(ctx1.cwd);
+    const filePath = path.join(ctx1.cwd, "shared.txt");
+    const session1 = await createSession(ctx1);
+    sessions.push(session1);
+    const session1Notifications = captureNotifications(session1);
+
+    ctx2 = await createContextForWorkspace(ctx1.rootDir, ctx1.cwd, false);
+    const session2 = await createSession(ctx2);
+    sessions.push(session2);
+    captureNotifications(session2);
+
+    ctx1.provider.setResponses([
+      fauxAssistantMessage([fauxToolCall("write", { path: "shared.txt", content: "session one\n" })]),
+      fauxAssistantMessage("created session one state"),
+    ]);
+    await session1.prompt("write session one state");
+    await waitFor(async () => await countSnapshots(session1, ctx1.cwd, "after") >= 1, "session one snapshot was not created");
+
+    ctx2.provider.setResponses([
+      fauxAssistantMessage([fauxToolCall("write", { path: "shared.txt", content: "session two\n" })]),
+      fauxAssistantMessage("created session two state"),
+    ]);
+    await session2.prompt("write session two state");
+    await waitFor(async () => await countSnapshots(session2, ctx2.cwd, "after") >= 1, "session two snapshot was not created");
+    await waitForText(filePath, "session two\n", "session two should own the latest workspace state");
+
+    const session1Leaf = session1.sessionManager.getLeafId();
+    await session1.prompt("/undo");
+    assert.equal(session1.sessionManager.getLeafId(), session1Leaf, "session one must not undo over session two's edit");
+    assert.equal(normalizeEol(await readText(filePath)), "session two\n", "a blocked undo must preserve session two's edit");
+    assert.ok(
+      session1Notifications.some((message) => /workspace changed|checkpoint/i.test(message)),
+      "session one should explain that another workspace edit blocks undo",
+    );
+
+    await session2.prompt("/undo");
+    await waitForText(filePath, "session one\n", "session two undo should restore the state it started from");
+    await session1.prompt("/undo");
+    await waitForExists(filePath, false, "session one undo should succeed once its state is current");
+
+    await session1.prompt("/redo");
+    await waitForText(filePath, "session one\n", "session one redo should restore its edit");
+    await session2.prompt("/redo");
+    await waitForText(filePath, "session two\n", "session two redo should restore its edit");
+
+    assert.equal(await getJujutsuOperationId(ctx1.cwd), operationId, "parallel Pi session history must not mutate Jujutsu operations");
+    assert.notEqual(getShadowGitDir(session1, ctx1.cwd), getShadowGitDir(session2, ctx2.cwd), "each Pi session needs an isolated shadow repository");
+    for (const session of sessions) {
+      const { stdout: trackedPaths } = await execFileAsync("git", shadowGitArgs(session, ctx1.cwd, "ls-files"), { cwd: ctx1.cwd });
+      assert.doesNotMatch(trackedPaths, /(^|\n)\.jj\//, "no Pi session may snapshot Jujutsu metadata");
+    }
+
+    const { stdout: jjStatus } = await execFileAsync("jj", ["--no-pager", "status"], { cwd: ctx1.cwd });
+    assert.match(jjStatus, /shared\.txt/, "Jujutsu should see the final restored edit");
+  } finally {
+    for (const session of sessions) {
+      session.dispose();
+    }
+    ctx2?.provider.unregister();
+    await disposeContext(ctx1);
+  }
+}
+
+async function testColocatedRepositoryMetadataRemainsUntouched(): Promise<void> {
+  if (!await hasJujutsu()) {
+    return;
+  }
+
+  const ctx = await createNonProjectContext();
+  try {
+    await execFileAsync("git", ["init", "-q"], { cwd: ctx.cwd });
+    await execFileAsync("git", ["config", "user.name", "workspace-history-test"], { cwd: ctx.cwd });
+    await execFileAsync("git", ["config", "user.email", "workspace-history-test@local"], { cwd: ctx.cwd });
+    await writeFile(path.join(ctx.cwd, ".gitignore"), "!.jj/\n!.jj/state\n", "utf8");
+    await writeFile(path.join(ctx.cwd, "repository.txt"), "repository state\n", "utf8");
+    await execFileAsync("git", ["add", ".gitignore", "repository.txt"], { cwd: ctx.cwd });
+    await execFileAsync("git", ["commit", "-m", "test repository state"], { cwd: ctx.cwd });
+    await execFileAsync("jj", ["--quiet", "git", "init", "--colocate", "."], { cwd: ctx.cwd });
+    const operationId = await getJujutsuOperationId(ctx.cwd);
+    const userHead = await readText(path.join(ctx.cwd, ".git", "HEAD"));
+    const userIndex = await readFile(path.join(ctx.cwd, ".git", "index"));
+
+    const session = await createSession(ctx);
+    const managedPath = path.join(ctx.cwd, "colocated-managed.txt");
+    ctx.provider.setResponses([
+      fauxAssistantMessage([fauxToolCall("write", { path: "colocated-managed.txt", content: "managed\n" })]),
+      fauxAssistantMessage("created colocated managed file"),
+    ]);
+
+    await session.prompt("create colocated-managed.txt");
+    await waitFor(async () => await countSnapshots(session, ctx.cwd, "after") >= 1, "colocated workspace snapshot was not created");
+    const { stdout: trackedPaths } = await execFileAsync("git", shadowGitArgs(session, ctx.cwd, "ls-files"), { cwd: ctx.cwd });
+    assert.doesNotMatch(trackedPaths, /(^|\n)\.(?:git|jj)\//, "VCS metadata must not enter snapshot history");
+
+    await session.prompt("/undo");
+    await waitForExists(managedPath, false, "colocated workspace undo should remove the managed file");
+    assert.equal(await readText(path.join(ctx.cwd, ".git", "HEAD")), userHead, "workspace undo must not change Git HEAD");
+    assert.deepEqual(await readFile(path.join(ctx.cwd, ".git", "index")), userIndex, "workspace undo must not change the Git index");
+    assert.equal(await getJujutsuOperationId(ctx.cwd), operationId, "workspace undo must not change Jujutsu operations");
+
+    await session.prompt("/redo");
+    await waitForText(managedPath, "managed\n", "colocated workspace redo should restore the managed file");
+    assert.equal(await readText(path.join(ctx.cwd, ".git", "HEAD")), userHead, "workspace redo must not change Git HEAD");
+    assert.deepEqual(await readFile(path.join(ctx.cwd, ".git", "index")), userIndex, "workspace redo must not change the Git index");
+    assert.equal(await getJujutsuOperationId(ctx.cwd), operationId, "workspace redo must not change Jujutsu operations");
+
+    const { stdout: jjStatus } = await execFileAsync("jj", ["--no-pager", "status"], { cwd: ctx.cwd });
+    assert.match(jjStatus, /colocated-managed\.txt/, "Jujutsu should report the restored colocated file");
 
     session.dispose();
   } finally {
@@ -2921,6 +3188,9 @@ async function testLegacyTrackedHardExcludeIsPrunedAndPreservedOnRestore(): Prom
   try {
     const envPath = path.join(ctx.cwd, ".env.local");
     await writeFile(envPath, "legacy secret\n", "utf8");
+    const jjStatePath = path.join(ctx.cwd, ".jj", "state");
+    await mkdir(path.dirname(jjStatePath), { recursive: true });
+    await writeFile(jjStatePath, "legacy Jujutsu state\n", "utf8");
     const session = await createSession(ctx);
     captureNotifications(session);
     ctx.provider.setResponses([
@@ -2932,7 +3202,7 @@ async function testLegacyTrackedHardExcludeIsPrunedAndPreservedOnRestore(): Prom
     await session.prompt("create first.txt");
     await waitFor(async () => await countSnapshots(session, ctx.cwd, "after") >= 1, "legacy fixture snapshot was not created");
 
-    await execFileAsync("git", shadowGitArgs(session, ctx.cwd, "add", "-f", "--", ".env.local"), { cwd: ctx.cwd });
+    await execFileAsync("git", shadowGitArgs(session, ctx.cwd, "add", "-f", "--", ".env.local", ".jj/state"), { cwd: ctx.cwd });
     await execFileAsync("git", [
       "-c", "user.name=workspace-history-test",
       "-c", "user.email=workspace-history-test@local",
@@ -2960,11 +3230,14 @@ async function testLegacyTrackedHardExcludeIsPrunedAndPreservedOnRestore(): Prom
       { cwd: ctx.cwd },
     );
     assert.doesNotMatch(trackedAfterUpgrade, /\.env\.local/, "new snapshots must prune hard excludes tracked by older versions");
+    assert.doesNotMatch(trackedAfterUpgrade, /\.jj\//, "new snapshots must prune Jujutsu metadata tracked by older versions");
 
     await writeFile(envPath, "current secret\n", "utf8");
+    await writeFile(jjStatePath, "current Jujutsu state\n", "utf8");
     const navigation = await session.navigateTree(oldSnapshotId, { summarize: false });
     assert.equal(navigation.cancelled, false, "restoring an old snapshot should ignore its hard-excluded files");
     assert.equal(normalizeEol(await readText(envPath)), "current secret\n", "old snapshots must not overwrite hard-excluded files");
+    assert.equal(normalizeEol(await readText(jjStatePath)), "current Jujutsu state\n", "old snapshots must not overwrite Jujutsu metadata");
     await waitForExists(path.join(ctx.cwd, "second.txt"), false, "managed files should still restore to the old snapshot");
     session.dispose();
   } finally {
@@ -3367,6 +3640,11 @@ async function main(): Promise<void> {
     { name: "session start does not create baseline eagerly", run: testSessionStartDoesNotCreateBaselineEagerly },
     { name: "idle warmup is reused by first turn", run: testIdleWarmupIsReusedByFirstTurn },
     { name: "non-project workspace disables extension", run: testNonProjectWorkspaceDisablesExtension },
+    { name: "Jujutsu-only workspace preserves metadata", run: testJujutsuOnlyWorkspacePreservesMetadata },
+    { name: "Jujutsu metadata directory disables workspace history", run: testJujutsuMetadataDirectoryDisablesExtension },
+    { name: "Git repository metadata remains untouched", run: testGitRepositoryMetadataRemainsUntouched },
+    { name: "concurrent Pi sessions preserve Jujutsu edits", run: testConcurrentSessionsInJujutsuWorkspace },
+    { name: "colocated repository metadata remains untouched", run: testColocatedRepositoryMetadataRemainsUntouched },
     { name: "internal storageDir disables extension", run: testInternalStorageDirDisablesExtension },
     { name: "project marker requirement can be disabled", run: testProjectMarkerRequirementCanBeDisabled },
     { name: "ancestor project markers enable subdirectories", run: testAncestorProjectMarkersEnableSubdirectories },

--- a/tests/workspace-history.test.ts
+++ b/tests/workspace-history.test.ts
@@ -3559,9 +3559,13 @@ async function testBranchSnapshotsSurviveGitPrune(): Promise<void> {
 }
 
 async function testMissingPreviousSnapshotFallsBackToFreshBefore(): Promise<void> {
-  const ctx = await createContext();
+  const previousLogging = process.env.PI_WORKSPACE_HISTORY_LOG;
+  process.env.PI_WORKSPACE_HISTORY_LOG = "1";
+  let ctx: TestContext | undefined;
   try {
+    ctx = await createContext();
     const session = await createSession(ctx);
+    const notifications = captureNotifications(session);
     ctx.provider.setResponses([
       fauxAssistantMessage([fauxToolCall("write", { path: "missing-snapshot.txt", content: "first\n" })]),
       fauxAssistantMessage("created first state"),
@@ -3569,7 +3573,16 @@ async function testMissingPreviousSnapshotFallsBackToFreshBefore(): Promise<void
     ]);
 
     await session.prompt("create first state");
-    await waitFor(async () => await countSnapshots(session, ctx.cwd, "after") === 1, "first snapshot missing");
+    try {
+      await waitFor(async () => await countSnapshots(session, ctx.cwd, "after") === 1, "first snapshot missing");
+    } catch (error) {
+      const logFile = path.join(getWorkspaceHistoryStateDir(ctx.rootDir), "logs", "timemachine.log");
+      const diagnosticLog = await readFile(logFile, "utf8").catch((logError) => `Unable to read ${logFile}: ${String(logError)}`);
+      throw new Error(
+        `First snapshot diagnostic failed. Notifications: ${notifications.join(" | ") || "none"}\n${diagnosticLog}`,
+        { cause: error },
+      );
+    }
     const first = (await readTurnSnapshots(session, ctx.cwd)).turns[0];
     assert.ok(first, "first turn snapshot should exist");
     assert.notEqual(first.beforeCommit, first.afterCommit, "fixture requires a distinct after commit");
@@ -3594,7 +3607,14 @@ async function testMissingPreviousSnapshotFallsBackToFreshBefore(): Promise<void
     await execFileAsync("git", ["--git-dir", gitDir, "cat-file", "-e", `${recovered.beforeCommit}^{commit}`], { cwd: ctx.cwd });
     session.dispose();
   } finally {
-    await disposeContext(ctx);
+    if (previousLogging === undefined) {
+      delete process.env.PI_WORKSPACE_HISTORY_LOG;
+    } else {
+      process.env.PI_WORKSPACE_HISTORY_LOG = previousLogging;
+    }
+    if (ctx) {
+      await disposeContext(ctx);
+    }
   }
 }
 


### PR DESCRIPTION
## Background

[Jujutsu (`jj`)](https://jj-vcs.dev/) is a Git-compatible version control system. It can use its own workspace layout or run in a colocated repository where both `jj` and regular Git commands operate on the same working copy.

## Problem

I use Pi in a colocated Git/Jujutsu repository, where workspace-history failed frequently during undo and restore.

The repository contains a `.jj/` directory holding Jujutsu metadata. workspace-history did not recognize `.jj/` as protected repository metadata, so its restore-time workspace scan could traverse thousands of internal Jujutsu files and exceed the configured scan limits.

There were two related problems:

- Pure Jujutsu repositories were not automatically recognized as projects.
- Starting Pi from inside `.jj/` could allow Jujutsu metadata to enter workspace snapshots.

## Changes

- Add `.jj` as a project marker.
- Add `.jj/` as a hard exclusion alongside `.git/`.
- Prevent workspace-history from running when the current directory is inside `.jj/`.
- Preserve `.jj/` when restoring old snapshots that may have tracked it.
- Document support for Git, Jujutsu, and colocated Git/Jujutsu repositories.
- Add integration coverage using real repositories created with `git init`, `jj git init --no-colocate`, and `jj git init --colocate`.
- Test two active Pi sessions making interleaved edits in the same Jujutsu workspace.

The snapshot backend remains the existing private shadow Git repository. This change does not invoke `jj` during normal extension operation or modify Git/Jujutsu repository history.

## Behavior

Workspace undo/redo restores working-copy files only. It does not rewind:

- Git commits, branches, or index state
- Jujutsu commits, bookmarks, or operations

After restoration, Git or Jujutsu may report the restored files as working-copy changes.

## Verification

- `npm run typecheck`
- Real Git repository undo/redo
- Real pure-Jujutsu repository undo/redo
- Real colocated Git/Jujutsu repository undo/redo
- Jujutsu metadata exclusion
- Multiple active Pi sessions in one Jujutsu workspace
- Git `HEAD` and index remain unchanged
- Jujutsu operation history remains unchanged
