### PR TITLE
feat: skip workspace history for multi-repo container directories without root git

### DIFF
--- a/.pi/extensions/workspace-history.ts
+++ b/.pi/extensions/workspace-history.ts
@@ -10,6 +10,7 @@ import {
   access,
   appendFile,
   mkdir,
+  opendir,
   readFile,
   realpath,
   rename,
@@ -38,6 +39,10 @@ const SHADOW_REPO_LOCK_WAIT_MS = 5_000;
 const SHADOW_REPO_LOCK_STALE_MS = 15_000;
 const RESTORE_FILE_LOCK_RETRY_DELAYS_MS = [100, 250, 500] as const;
 const WORKSPACE_HISTORY_LOG_ENV = "PI_WORKSPACE_HISTORY_LOG";
+const MULTI_REPO_SCAN_MAX_DIRS = 256;
+const MULTI_REPO_SCAN_MAX_MS = 250;
+const MULTI_REPO_SCAN_BATCH_SIZE = 16;
+const MULTI_REPO_SCAN_CACHE_MS = 30_000;
 const PROJECT_MARKER_FILES = [
   ".git",
   ".jj",
@@ -56,6 +61,7 @@ const PROJECT_MARKER_FILES = [
 type SnapshotKind = "baseline" | "before" | "after" | "manual";
 type WorkspaceComparison = "clean" | "dirty" | "missing";
 type NavigationMode = "conversationAndWorkspace" | "conversationOnly";
+type MultiRepoScanOutcome = "not-container" | "container" | "time-limit" | "directory-limit" | "error";
 
 const NAVIGATION_MODE_OPTIONS = [
   "Conversation and workspace",
@@ -123,6 +129,13 @@ interface PendingRecoveryState {
   createdAt: string;
 }
 
+interface MultiRepoContainerCache {
+  cwd: string;
+  rootMtimeMs: number;
+  checkedAt: number;
+  isContainer: boolean;
+}
+
 interface RuntimeState {
   pendingTurnId?: string;
   pendingBeforeCommit?: string;
@@ -169,6 +182,7 @@ interface RuntimeState {
   validatedShadowGitDir?: string;
   warnedMissingSnapshotCommits?: Set<string>;
   sessionLeaseOwnerId?: string;
+  multiRepoContainerCache?: MultiRepoContainerCache;
 }
 
 interface NavigationPrecheckResult {
@@ -418,25 +432,133 @@ async function isInsideJujutsuMetadata(cwd: string): Promise<boolean> {
   }
 }
 
-async function isMultiRepoContainer(cwd: string): Promise<boolean> {
+async function countRepositoryRoots(directoryPaths: string[], deadline: number): Promise<number | undefined> {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) {
+    return undefined;
+  }
+
   try {
-    const entries = await readdir(cwd, { withFileTypes: true });
-    let repoCount = 0;
-    for (const entry of entries) {
-      if (entry.isDirectory() && !entry.name.startsWith(".")) {
-        const subDir = path.join(cwd, entry.name);
-        if (await pathExists(path.join(subDir, ".git")) || await pathExists(path.join(subDir, ".jj"))) {
-          repoCount++;
-          if (repoCount >= 2) {
-            return true;
-          }
+    const markers = await withTimeout(
+      Promise.all(directoryPaths.map(async (directoryPath) => {
+        const [hasGit, hasJujutsu] = await Promise.all([
+          pathExists(path.join(directoryPath, ".git")),
+          pathExists(path.join(directoryPath, ".jj")),
+        ]);
+        return hasGit || hasJujutsu;
+      })),
+      remainingMs,
+      "multi-repo marker scan",
+    );
+    return markers.filter(Boolean).length;
+  } catch {
+    return undefined;
+  }
+}
+
+async function isMultiRepoContainer(
+  ctx: ExtensionContext,
+  cwd: string,
+  state?: RuntimeState,
+): Promise<boolean> {
+  const normalizedCwd = normalizePathForComparison(cwd);
+  const rootStat = await stat(cwd).catch(() => undefined);
+  if (!rootStat?.isDirectory()) {
+    return false;
+  }
+
+  const now = Date.now();
+  const cached = state?.multiRepoContainerCache;
+  if (
+    cached &&
+    cached.cwd === normalizedCwd &&
+    cached.rootMtimeMs === rootStat.mtimeMs &&
+    now - cached.checkedAt < MULTI_REPO_SCAN_CACHE_MS
+  ) {
+    return cached.isContainer;
+  }
+
+  const startedAt = now;
+  const deadline = startedAt + MULTI_REPO_SCAN_MAX_MS;
+  const pendingDirectories: string[] = [];
+  let checkedDirs = 0;
+  let repoCount = 0;
+  let outcome: MultiRepoScanOutcome = "not-container";
+
+  const openPromise = opendir(cwd);
+  const directory = await withTimeout(
+    openPromise,
+    Math.max(1, deadline - Date.now()),
+    "multi-repo directory open",
+  ).catch(() => undefined);
+  if (!directory) {
+    outcome = Date.now() >= deadline ? "time-limit" : "error";
+    void openPromise.then((lateDirectory) => lateDirectory.close()).catch(() => undefined);
+  }
+
+  try {
+    for await (const entry of directory ?? []) {
+      if (Date.now() >= deadline) {
+        outcome = "time-limit";
+        break;
+      }
+      if (!entry.isDirectory() || entry.name.startsWith(".")) {
+        continue;
+      }
+      if (checkedDirs >= MULTI_REPO_SCAN_MAX_DIRS) {
+        outcome = "directory-limit";
+        break;
+      }
+
+      checkedDirs++;
+      pendingDirectories.push(path.join(cwd, entry.name));
+      if (pendingDirectories.length < MULTI_REPO_SCAN_BATCH_SIZE) {
+        continue;
+      }
+
+      const found = await countRepositoryRoots(pendingDirectories, deadline);
+      pendingDirectories.length = 0;
+      if (found === undefined) {
+        outcome = "time-limit";
+        break;
+      }
+      repoCount += found;
+      if (repoCount >= 2) {
+        outcome = "container";
+        break;
+      }
+    }
+
+    if (outcome === "not-container" && pendingDirectories.length > 0) {
+      const found = await countRepositoryRoots(pendingDirectories, deadline);
+      if (found === undefined) {
+        outcome = "time-limit";
+      } else {
+        repoCount += found;
+        if (repoCount >= 2) {
+          outcome = "container";
         }
       }
     }
   } catch {
-    return false;
+    outcome = "error";
   }
-  return false;
+
+  const isContainer = outcome === "container";
+  if (state) {
+    state.multiRepoContainerCache = {
+      cwd: normalizedCwd,
+      rootMtimeMs: rootStat.mtimeMs,
+      checkedAt: Date.now(),
+      isContainer,
+    };
+  }
+  await logLine(
+    ctx,
+    `multi-repo scan done ${elapsedMs(startedAt)}ms outcome=${outcome} checkedDirs=${checkedDirs} repoCount=${repoCount}`,
+    state,
+  ).catch(() => undefined);
+  return isContainer;
 }
 
 function normalizePathForComparison(filePath: string): string {
@@ -538,8 +660,8 @@ async function evaluateWorkspaceHistoryAvailability(ctx: ExtensionContext, state
       availability = { enabled: false, reason: "current directory is a filesystem root" };
     } else if (settings.requireProjectMarker && !(await hasProjectMarker(resolvedCwd))) {
       availability = { enabled: false, reason: "no project marker found" };
-    } else if (!(await pathExists(path.join(resolvedCwd, ".git"))) && !(await pathExists(path.join(resolvedCwd, ".jj"))) && (await isMultiRepoContainer(resolvedCwd))) {
-      availability = { enabled: false, reason: "workspace is a multi-repo container without root git" };
+    } else if (settings.requireProjectMarker && !(await pathExists(path.join(resolvedCwd, ".git"))) && !(await pathExists(path.join(resolvedCwd, ".jj"))) && (await isMultiRepoContainer(ctx, resolvedCwd, state))) {
+      availability = { enabled: false, reason: "workspace is a multi-repo container without a root repository" };
     } else {
       availability = { enabled: true };
     }
@@ -2992,6 +3114,7 @@ export default function workspaceHistoryExtension(pi: ExtensionAPI) {
     state.validatedShadowGitDir = undefined;
     state.warnedMissingSnapshotCommits = undefined;
     state.sessionLeaseOwnerId = undefined;
+    state.multiRepoContainerCache = undefined;
 
     if (!await ensureWorkspaceHistoryAvailable(ctx, state, "session_start")) {
       return;

--- a/.pi/extensions/workspace-history.ts
+++ b/.pi/extensions/workspace-history.ts
@@ -418,6 +418,27 @@ async function isInsideJujutsuMetadata(cwd: string): Promise<boolean> {
   }
 }
 
+async function isMultiRepoContainer(cwd: string): Promise<boolean> {
+  try {
+    const entries = await readdir(cwd, { withFileTypes: true });
+    let repoCount = 0;
+    for (const entry of entries) {
+      if (entry.isDirectory() && !entry.name.startsWith(".")) {
+        const subDir = path.join(cwd, entry.name);
+        if (await pathExists(path.join(subDir, ".git")) || await pathExists(path.join(subDir, ".jj"))) {
+          repoCount++;
+          if (repoCount >= 2) {
+            return true;
+          }
+        }
+      }
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
 function normalizePathForComparison(filePath: string): string {
   const normalized = path.normalize(filePath);
   return process.platform === "win32" ? normalized.toLowerCase() : normalized;
@@ -517,6 +538,8 @@ async function evaluateWorkspaceHistoryAvailability(ctx: ExtensionContext, state
       availability = { enabled: false, reason: "current directory is a filesystem root" };
     } else if (settings.requireProjectMarker && !(await hasProjectMarker(resolvedCwd))) {
       availability = { enabled: false, reason: "no project marker found" };
+    } else if (!(await pathExists(path.join(resolvedCwd, ".git"))) && !(await pathExists(path.join(resolvedCwd, ".jj"))) && (await isMultiRepoContainer(resolvedCwd))) {
+      availability = { enabled: false, reason: "workspace is a multi-repo container without root git" };
     } else {
       availability = { enabled: true };
     }

--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ Settings:
   - Default: `10`
 - `workspaceHistory.enabled`
   - `auto` (default) enables the plugin when the current directory or an ancestor contains a declared project marker
-  - `true` forces it on
+  - In automatic mode with project markers required, a directory without its own `.git` or `.jj` is skipped when at least two immediate non-hidden child directories are repositories
+  - This multi-repo container check is shallow and bounded; if it cannot finish confidently, workspace history stays enabled
+  - `true` forces it on, including for multi-repo container directories
   - `false` disables it completely
 - `workspaceHistory.allowHomeDirectory`
   - Allow enabling in the user home directory
@@ -186,7 +188,7 @@ Settings:
 - `workspaceHistory.requireProjectMarker`
   - Require a project marker such as `.git`, `.jj`, `package.json`, `Cargo.toml`, `go.mod`, or `pyproject.toml` in the current directory or an ancestor
   - Default: `true`
-  - When `false`, automatic mode accepts any directory except a filesystem root or the user home directory (unless `allowHomeDirectory` is also enabled)
+  - When `false`, automatic mode accepts any directory except a filesystem root or the user home directory (unless `allowHomeDirectory` is also enabled), and skips multi-repo container detection
 - `workspaceHistory.maxScanFiles`
 - `workspaceHistory.maxScanDirs`
 - `workspaceHistory.maxScanMs`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -178,7 +178,9 @@
   - 默认：`10`
 - `workspaceHistory.enabled`
   - `auto`（默认）在当前目录或祖先目录存在已声明项目标记时启用
-  - `true` 强制启用
+  - 自动模式且要求项目标记时，如果当前目录自身没有 `.git` 或 `.jj`，但至少两个直属非隐藏子目录是仓库，则插件会跳过该多仓库容器目录
+  - 多仓库容器检查是浅层且有界的；无法可靠完成判断时，workspace-history 继续启用
+  - `true` 强制启用，包括多仓库容器目录
   - `false` 完全禁用
 - `workspaceHistory.allowHomeDirectory`
   - 是否允许在用户 home 目录启用
@@ -186,7 +188,7 @@
 - `workspaceHistory.requireProjectMarker`
   - 是否要求当前目录或祖先目录存在 `.git`、`.jj`、`package.json`、`Cargo.toml`、`go.mod`、`pyproject.toml` 等项目标记
   - 默认：`true`
-  - 设为 `false` 时，自动模式允许文件系统根目录和用户 home 目录以外的任意目录（home 目录仍需同时启用 `allowHomeDirectory`）
+  - 设为 `false` 时，自动模式允许文件系统根目录和用户 home 目录以外的任意目录（home 目录仍需同时启用 `allowHomeDirectory`），并跳过多仓库容器判断
 - `workspaceHistory.maxScanFiles`
 - `workspaceHistory.maxScanDirs`
 - `workspaceHistory.maxScanMs`

--- a/tests/workspace-history.test.ts
+++ b/tests/workspace-history.test.ts
@@ -34,6 +34,9 @@ type TestContext = {
   provider: ReturnType<typeof fauxProvider> & { unregister(): void };
 };
 
+type TestSession = Awaited<ReturnType<typeof createAgentSession>>["session"];
+type TestUIContext = Parameters<TestSession["extensionRunner"]["setUIContext"]>[0];
+
 type TurnSnapshotState = {
   version: 1;
   turns: Array<{
@@ -166,6 +169,22 @@ async function createNonProjectContext(): Promise<TestContext> {
   return createContextForWorkspace(rootDir, cwd, false);
 }
 
+async function initializeGitRepository(repoDir: string): Promise<void> {
+  await mkdir(repoDir, { recursive: true });
+  await execFileAsync("git", ["init", "--quiet", repoDir]);
+  await writeFile(path.join(repoDir, "tracked.txt"), "tracked\n", "utf8");
+  await execFileAsync("git", ["-C", repoDir, "add", "tracked.txt"]);
+  await execFileAsync(
+    "git",
+    ["-C", repoDir, "-c", "user.name=workspace-history-test", "-c", "user.email=test@example.invalid", "commit", "--quiet", "-m", "initial"],
+  );
+}
+
+async function initializeEmptyGitRepository(repoDir: string): Promise<void> {
+  await mkdir(repoDir, { recursive: true });
+  await execFileAsync("git", ["init", "--quiet", repoDir]);
+}
+
 async function writeWorkspaceHistorySettings(
   ctx: TestContext,
   workspaceHistory: Record<string, unknown>,
@@ -187,7 +206,11 @@ async function disposeContext(ctx: TestContext): Promise<void> {
   });
 }
 
-async function createSession(ctx: TestContext, sessionManager: SessionManager = SessionManager.inMemory(ctx.cwd)) {
+async function createSession(
+  ctx: TestContext,
+  sessionManager: SessionManager = SessionManager.inMemory(ctx.cwd),
+  uiContext?: TestUIContext,
+) {
   const model = ctx.provider.getModel();
   const result = await createAgentSession({
     cwd: ctx.cwd,
@@ -203,6 +226,7 @@ async function createSession(ctx: TestContext, sessionManager: SessionManager = 
 
   const session = result.session;
   await session.bindExtensions({
+    uiContext,
     commandContextActions: {
       waitForIdle: () => session.agent.waitForIdle(),
       newSession: async () => ({ cancelled: true }),
@@ -641,7 +665,29 @@ function configureTestUI(
     notifications: [],
     selections: [],
   };
-  type UIContext = Parameters<typeof session.extensionRunner.setUIContext>[0];
+  session.extensionRunner.setUIContext(createTestUIContext(state, choices, selectFirstByDefault));
+  return state;
+}
+
+async function withWorkspaceHistoryLogging<T>(run: () => Promise<T>): Promise<T> {
+  const previousLogging = process.env.PI_WORKSPACE_HISTORY_LOG;
+  process.env.PI_WORKSPACE_HISTORY_LOG = "1";
+  try {
+    return await run();
+  } finally {
+    if (previousLogging === undefined) {
+      delete process.env.PI_WORKSPACE_HISTORY_LOG;
+    } else {
+      process.env.PI_WORKSPACE_HISTORY_LOG = previousLogging;
+    }
+  }
+}
+
+function createTestUIContext(
+  state: TestUIState,
+  choices: string[],
+  selectFirstByDefault = false,
+): TestUIContext {
   const uiContext = new Proxy({
     async select(title: string, options: string[]): Promise<string | undefined> {
       state.selections.push({ title, options: [...options] });
@@ -657,9 +703,8 @@ function configureTestUI(
     get(target, property) {
       return Reflect.get(target, property) ?? (() => undefined);
     },
-  }) as UIContext;
-  session.extensionRunner.setUIContext(uiContext);
-  return state;
+  }) as TestUIContext;
+  return uiContext;
 }
 
 async function testUndoConversationOnlyKeepsWorkspace(): Promise<void> {
@@ -2652,6 +2697,276 @@ async function testProjectMarkerRequirementCanBeDisabled(): Promise<void> {
   }
 }
 
+async function testProjectMarkerOverrideAllowsMultiRepoContainers(): Promise<void> {
+  const ctx = await createNonProjectContext();
+  try {
+    await initializeGitRepository(path.join(ctx.cwd, "repo-a"));
+    await initializeGitRepository(path.join(ctx.cwd, "repo-b"));
+    await writeWorkspaceHistorySettings(ctx, {
+      storageDir: getWorkspaceHistoryStateDir(ctx.rootDir),
+      requireProjectMarker: false,
+    });
+    const session = await createSession(ctx);
+    const notifications = captureNotifications(session);
+    ctx.provider.setResponses([
+      fauxAssistantMessage([fauxToolCall("write", { path: "markerless.txt", content: "enabled\n" })]),
+      fauxAssistantMessage("enabled markerless history"),
+    ]);
+
+    await session.prompt("create markerless.txt");
+
+    assert.equal(
+      notifications.some((message) => message.includes("multi-repo container")),
+      false,
+      "requireProjectMarker=false should not auto-disable a multi-repo container",
+    );
+    await waitFor(
+      async () => await countSnapshots(session, ctx.cwd, "after") >= 1,
+      "requireProjectMarker=false should keep workspace history enabled for a multi-repo container",
+    );
+    session.dispose();
+  } finally {
+    await disposeContext(ctx);
+  }
+}
+
+async function testMultiRepoContainerDisablesWorkspaceHistory(): Promise<void> {
+  const ctx = await createContext();
+  try {
+    await initializeGitRepository(path.join(ctx.cwd, "repo-a"));
+    await initializeEmptyGitRepository(path.join(ctx.cwd, "repo-empty"));
+    const uiState: TestUIState = { notifications: [], selections: [] };
+    const session = await createSession(ctx, undefined, createTestUIContext(uiState, [], true));
+    const notifications = uiState.notifications;
+    ctx.provider.setResponses([
+      fauxAssistantMessage([fauxToolCall("write", { path: "first.txt", content: "first\n" })]),
+      fauxAssistantMessage("created first file"),
+    ]);
+
+    await session.prompt("create first.txt");
+    await waitForExists(path.join(ctx.cwd, "first.txt"), true, "the agent should still edit files when history is disabled");
+    assert.equal(await countSnapshots(session, ctx.cwd), 0, "a multi-repo container must not create snapshots");
+    assert.equal(
+      await pathExists(getWorkspaceHistoryStateDir(ctx.rootDir)),
+      false,
+      "a disabled multi-repo container must not create workspace history storage",
+    );
+    assert.equal(
+      notifications.filter((message) => message.includes("multi-repo container without a root repository")).length,
+      1,
+      "a multi-repo container should show one actionable warning",
+    );
+
+    ctx.provider.setResponses([
+      fauxAssistantMessage([fauxToolCall("write", { path: "second.txt", content: "second\n" })]),
+      fauxAssistantMessage("created second file"),
+    ]);
+    await session.prompt("create second.txt");
+
+    assert.equal(await countSnapshots(session, ctx.cwd), 0, "later turns must remain unsnapshotted in a multi-repo container");
+    assert.equal(
+      notifications.filter((message) => message.includes("multi-repo container without a root repository")).length,
+      1,
+      "the disabled warning should not repeat on later turns",
+    );
+    session.dispose();
+  } finally {
+    await disposeContext(ctx);
+  }
+}
+
+async function testMixedGitAndJujutsuChildrenDisableWorkspaceHistory(): Promise<void> {
+  const ctx = await createContext();
+  try {
+    await initializeGitRepository(path.join(ctx.cwd, "git-project"));
+    await mkdir(path.join(ctx.cwd, "jj-project", ".jj"), { recursive: true });
+    const session = await createSession(ctx);
+    ctx.provider.setResponses([fauxAssistantMessage("no file changes")]);
+
+    await session.prompt("answer without changing files");
+
+    assert.equal(
+      await countSnapshots(session, ctx.cwd),
+      0,
+      "Git and Jujutsu child repositories together should identify a multi-repo container",
+    );
+    session.dispose();
+  } finally {
+    await disposeContext(ctx);
+  }
+}
+
+async function testSingleChildRepositoryKeepsWorkspaceHistoryEnabled(): Promise<void> {
+  const ctx = await createContext();
+  try {
+    await initializeGitRepository(path.join(ctx.cwd, "repo-a"));
+    const session = await createSession(ctx);
+    ctx.provider.setResponses([
+      fauxAssistantMessage([fauxToolCall("write", { path: "managed.txt", content: "managed\n" })]),
+      fauxAssistantMessage("created managed file"),
+    ]);
+
+    await session.prompt("create managed.txt");
+
+    await waitFor(
+      async () => await countSnapshots(session, ctx.cwd, "after") >= 1,
+      "one child repository should not disable workspace history",
+    );
+    session.dispose();
+  } finally {
+    await disposeContext(ctx);
+  }
+}
+
+async function testRootRepositoryKeepsMultiRepoWorkspaceEnabled(): Promise<void> {
+  for (const marker of [".git", ".jj"] as const) {
+    const ctx = await createContext();
+    try {
+      if (marker === ".git") {
+        await execFileAsync("git", ["init", "--quiet", ctx.cwd]);
+      } else {
+        await mkdir(path.join(ctx.cwd, marker));
+      }
+      await initializeGitRepository(path.join(ctx.cwd, "repo-a"));
+      await initializeGitRepository(path.join(ctx.cwd, "repo-b"));
+      const session = await createSession(ctx);
+      ctx.provider.setResponses([
+        fauxAssistantMessage([fauxToolCall("write", { path: "managed.txt", content: `${marker}\n` })]),
+        fauxAssistantMessage("created managed file"),
+      ]);
+
+      await session.prompt("create managed.txt");
+
+      await waitFor(
+        async () => await countSnapshots(session, ctx.cwd, "after") >= 1,
+        `a root ${marker} repository should keep workspace history enabled`,
+      );
+      session.dispose();
+    } finally {
+      await disposeContext(ctx);
+    }
+  }
+}
+
+async function testForcedEnableAllowsMultiRepoContainers(): Promise<void> {
+  const ctx = await createContext();
+  try {
+    await initializeGitRepository(path.join(ctx.cwd, "repo-a"));
+    await initializeGitRepository(path.join(ctx.cwd, "repo-b"));
+    await writeWorkspaceHistorySettings(ctx, {
+      storageDir: getWorkspaceHistoryStateDir(ctx.rootDir),
+      enabled: true,
+    });
+    const session = await createSession(ctx);
+    ctx.provider.setResponses([
+      fauxAssistantMessage([fauxToolCall("write", { path: "forced.txt", content: "forced\n" })]),
+      fauxAssistantMessage("created forced file"),
+    ]);
+
+    await session.prompt("create forced.txt");
+
+    await waitFor(
+      async () => await countSnapshots(session, ctx.cwd, "after") >= 1,
+      "enabled=true should force workspace history on in a multi-repo container",
+    );
+    session.dispose();
+  } finally {
+    await disposeContext(ctx);
+  }
+}
+
+async function testMultiRepoContainerScanIsCached(): Promise<void> {
+  await withWorkspaceHistoryLogging(async () => {
+    const ctx = await createContext();
+    try {
+      await initializeGitRepository(path.join(ctx.cwd, "repo-a"));
+      await initializeGitRepository(path.join(ctx.cwd, "repo-b"));
+      const session = await createSession(ctx);
+      ctx.provider.setResponses([fauxAssistantMessage("no file changes")]);
+
+      await session.prompt("answer without changing files");
+
+      const logPath = path.join(getWorkspaceHistoryStateDir(ctx.rootDir), "logs", "timemachine.log");
+      await waitForExists(logPath, true, "diagnostic log should be created");
+      const logText = await readText(logPath);
+      assert.equal(
+        logText.split("\n").filter((line) => line.includes("multi-repo scan done")).length,
+        1,
+        "repeated agent events should reuse one multi-repo scan result",
+      );
+      await session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
+      session.dispose();
+    } finally {
+      await disposeContext(ctx);
+    }
+  });
+}
+
+async function testMultiRepoContainerScanIsBounded(): Promise<void> {
+  await withWorkspaceHistoryLogging(async () => {
+    const ctx = await createContext();
+    try {
+      await Promise.all(Array.from({ length: 300 }, (_, index) => {
+        return mkdir(path.join(ctx.cwd, `directory-${String(index).padStart(3, "0")}`));
+      }));
+      const session = await createSession(ctx);
+      ctx.provider.setResponses([fauxAssistantMessage("no file changes")]);
+
+      await session.prompt("answer without changing files");
+
+      await waitFor(
+        async () => await countSnapshots(session, ctx.cwd, "after") >= 1,
+        "an inconclusive bounded scan should leave workspace history enabled",
+      );
+      const logPath = path.join(getWorkspaceHistoryStateDir(ctx.rootDir), "logs", "timemachine.log");
+      const logText = await readText(logPath);
+      const scanMatch = logText.match(
+        /multi-repo scan done .* outcome=(directory-limit|time-limit) checkedDirs=(\d+) repoCount=0/,
+      );
+      assert.ok(scanMatch, "the multi-repo scan should stop at a configured safety limit");
+      assert.ok(Number(scanMatch[2]) <= 256, "the multi-repo scan must not inspect more than 256 directories");
+      await session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
+      session.dispose();
+    } finally {
+      await disposeContext(ctx);
+    }
+  });
+}
+
+async function testMultiRepoContainerCacheInvalidatesAfterDirectoryChange(): Promise<void> {
+  const ctx = await createContext();
+  try {
+    await initializeGitRepository(path.join(ctx.cwd, "repo-a"));
+    const session = await createSession(ctx);
+    const notifications = captureNotifications(session);
+    ctx.provider.setResponses([fauxAssistantMessage("first turn")]);
+
+    await session.prompt("complete the first turn without changing files");
+    await waitFor(
+      async () => await countSnapshots(session, ctx.cwd, "after") === 1,
+      "one child repository should allow the first snapshot",
+    );
+
+    await initializeGitRepository(path.join(ctx.cwd, "repo-b"));
+    ctx.provider.setResponses([fauxAssistantMessage("second turn")]);
+    await session.prompt("complete the second turn without changing files");
+
+    assert.equal(
+      await countSnapshots(session, ctx.cwd, "after"),
+      1,
+      "adding a second child repository should invalidate the cache and stop new snapshots",
+    );
+    assert.equal(
+      notifications.filter((message) => message.includes("multi-repo container without a root repository")).length,
+      1,
+      "the newly detected multi-repo container should show one warning",
+    );
+    session.dispose();
+  } finally {
+    await disposeContext(ctx);
+  }
+}
+
 async function testAncestorProjectMarkersEnableSubdirectories(): Promise<void> {
   const markers = [".git", "Cargo.toml", "go.mod", "pyproject.toml"];
   for (const marker of markers) {
@@ -3676,6 +3991,15 @@ async function main(): Promise<void> {
     { name: "colocated repository metadata remains untouched", run: testColocatedRepositoryMetadataRemainsUntouched },
     { name: "internal storageDir disables extension", run: testInternalStorageDirDisablesExtension },
     { name: "project marker requirement can be disabled", run: testProjectMarkerRequirementCanBeDisabled },
+    { name: "project marker override allows multi-repo containers", run: testProjectMarkerOverrideAllowsMultiRepoContainers },
+    { name: "multi-repo container disables workspace history", run: testMultiRepoContainerDisablesWorkspaceHistory },
+    { name: "mixed Git and Jujutsu children disable workspace history", run: testMixedGitAndJujutsuChildrenDisableWorkspaceHistory },
+    { name: "single child repository keeps workspace history enabled", run: testSingleChildRepositoryKeepsWorkspaceHistoryEnabled },
+    { name: "root repository keeps multi-repo workspace enabled", run: testRootRepositoryKeepsMultiRepoWorkspaceEnabled },
+    { name: "forced enable allows multi-repo containers", run: testForcedEnableAllowsMultiRepoContainers },
+    { name: "multi-repo container scan is cached", run: testMultiRepoContainerScanIsCached },
+    { name: "multi-repo container scan is bounded", run: testMultiRepoContainerScanIsBounded },
+    { name: "multi-repo container cache invalidates after directory change", run: testMultiRepoContainerCacheInvalidatesAfterDirectoryChange },
     { name: "ancestor project markers enable subdirectories", run: testAncestorProjectMarkersEnableSubdirectories },
     { name: "conversation-only undo keeps workspace", run: testUndoConversationOnlyKeepsWorkspace },
     { name: "redo reuses conversation-only undo mode", run: testRedoReusesConversationOnlyMode },

--- a/tests/workspace-history.test.ts
+++ b/tests/workspace-history.test.ts
@@ -476,7 +476,10 @@ async function holdWindowsFileWithoutDeleteSharing(
   try {
     await new Promise<void>((resolve, reject) => {
       let stdout = "";
-      const timeout = setTimeout(() => reject(new Error("timed out waiting for the Windows file lock helper")), 5_000);
+      const timeout = setTimeout(
+        () => reject(new Error("timed out waiting for the Windows file lock helper")),
+        ASYNC_ASSERTION_TIMEOUT_MS,
+      );
       child.stdout.on("data", (chunk) => {
         stdout += chunk.toString();
         if (!ready && stdout.includes("READY")) {


### PR DESCRIPTION
### Problem / Pain Point
When developers open a parent/aggregate directory (e.g. `~/workspace`, `~/projects`, or a folder containing dozens of independent sub-projects) where:
1. The root directory has NO `.git` or `.jj` repository of its own.
2. The root directory happens to contain a generic `package.json` (e.g. for workspace-level scripts or tooling).
3. Immediate subdirectories contain independent git repositories.

Currently, `hasProjectMarker()` detects the root `package.json` and enables `workspace-history`. The extension then attempts to run `git add -A -- .` across the entire multi-repo tree, trying to snapshot thousands of nested repo files, individual `node_modules`, and large temporary logs. This leads to:
- Severe lag / hangs during turns.
- Frequent `index.lock: File exists` errors and conflicts.

### Solution (Minimal & Non-intrusive)
Add a shallow heuristic check `isMultiRepoContainer()`:
- If the current workspace root has no `.git` and no `.jj`;
- And contains $\ge 2$ immediate subdirectories that are their own `.git` or `.jj` repositories;
- Disable `workspace-history` automatically with reason `workspace is a multi-repo container without root git`.

This avoids accidental giant shadow snapshots while still allowing the extension to activate normally when a user navigates directly into any individual sub-project.